### PR TITLE
readme: fix up link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,4 +4,4 @@ A community for those working on, or interested in, building operating system
 images.
 
 - [Image Build Tools](https://github.com/OSMakers/image-build-tools).
-- [Image Build Description Specification](https://github.com/OSMakers/image-build-description-specification).
+- [Image Build Description Specification](https://github.com/OSMakers/image-build-desc-spec).


### PR DESCRIPTION
The link to the `image-build-desc-spec` is wrong.